### PR TITLE
First draft for n tasks in time intervals

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,12 +1,23 @@
+End-user:
+=========
+
 [X] Cumulative resources: resources that can process multiple tasks at the same time
 
 [X] Optional tasks: tasks that may or may not be scheduled
 
 [ ] Inventories: input/output for tasks
 
-[X] Add a plotly/pandas gantt renderer with real datetimes
+[X] Add a plotly/pandas gantt renderer with real dates and times
+
+[ ] JSON importer/exporter for a scheduling problem
+
+Dev:
+====
 
 [ ] Performance benchmark
 
-[ ] JSON importer for a scheduling problem
+[ ] Improve class hierarchy and inheritance
 
+[ ] Categorize task constraints
+
+[ ] Developer user guide, especially how to add constraints

--- a/processscheduler/task_constraint.py
+++ b/processscheduler/task_constraint.py
@@ -17,7 +17,7 @@
 
 from typing import Optional
 
-from z3 import And, Bool, Not, BoolRef, Implies, If, Or, Xor, PbEq, PbGe, PbLe
+from z3 import And, Bool, Not, BoolRef, Implies, Xor, PbEq, PbGe, PbLe
 
 from processscheduler.base import _Constraint
 
@@ -293,16 +293,6 @@ class ScheduleNTasksInTimeIntervals(_TaskConstraint):
 
         if not isinstance(list_of_time_intervals, list):
             raise TypeError('list_of_time_intervals must be a list of list')
-
-        # check for special case
-        # for the first interval, it is a bit special: if the lower bound is different
-        # from zero, we have to handle the case where the start and/or end are scheduled
-        # before the first allowed interval
-        first_interval = list_of_time_intervals[0]
-        lower_bound_first_interval = first_interval[0]
-        is_first_bound_greater_than_zero = False
-        if lower_bound_first_interval > 0:
-            is_first_bound_greater_than_zero = True
 
         # count the number of tasks that re scheduled in this time interval
         all_bools =[]

--- a/processscheduler/task_constraint.py
+++ b/processscheduler/task_constraint.py
@@ -300,17 +300,18 @@ class ScheduleNTasksInTimeIntervals(_TaskConstraint):
             # for this task, the logic expression is that any of its start or end must be
             # between two consecutive intervals
             i = 0
-            b = Bool('InTimeIntervalTask_%s_%i' % (task.name, i))
             cstrs = []
             for time_interval in list_of_time_intervals:
+                b = Bool('InTimeIntervalTask_%s_%i' % (task.name, i))
                 lower_bound, upper_bound = time_interval
                 cstrs += [task.start >= lower_bound, task.end <= upper_bound,
-                             Not(And(task.start < lower_bound, task.end > lower_bound)),  # overlap at start
-                             Not(And(task.start < upper_bound, task.end > upper_bound)),   # overlap at end
-                             Not(And(task.start < lower_bound, task.end > upper_bound))]   # full overlap
-            asst = Implies(b, And(cstrs))
-            self.set_applied_not_applied_assertions(asst)
-            all_bools.append(b)
+                          Not(And(task.start < lower_bound, task.end > lower_bound)),  # overlap at start
+                          Not(And(task.start < upper_bound, task.end > upper_bound)),   # overlap at end
+                          Not(And(task.start < lower_bound, task.end > upper_bound))]   # full overlap
+                asst = Implies(b, And(cstrs))
+                self.set_applied_not_applied_assertions(asst)
+                all_bools.append(b)
+                i += 1
 
         # we also have to exclude all the other cases, where start or end can be between two intervals
         # then set the constraint for the number of tasks to schedule

--- a/test/test_schedule_n_task_in_time_interval.py
+++ b/test/test_schedule_n_task_in_time_interval.py
@@ -67,8 +67,8 @@ class ScheduleNTasksInTimeIntervals(unittest.TestCase):
         pb.add_constraint(cstrt)
         # force task_1 to be shceduled after 10. So the only solution is that task 2 is scheduled
         # before 10
-        ctr1 = ps.TaskStartAfterLax(task_1, 10)
-
+        cstrt1 = ps.TaskStartAfterLax(task_1, 10)
+        pb.add_constraint(cstrt1)
         solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
         self.assertTrue(solution)

--- a/test/test_schedule_n_task_in_time_interval.py
+++ b/test/test_schedule_n_task_in_time_interval.py
@@ -90,29 +90,44 @@ class ScheduleNTasksInTimeIntervals(unittest.TestCase):
     def test_double_interval_1(self) -> None:
         pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervalsDoubleInterval1', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
-        task_2 = ps.FixedDurationTask('task2', duration = 3)
 
-        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
-                                                 nb_tasks_to_schedule= 2,
-                                                 list_of_time_intervals = [[5, 10], [15, 19]])
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1],
+                                                 nb_tasks_to_schedule= 1,
+                                                 list_of_time_intervals = [[5,7], [15, 18]])
         pb.add_constraint(cstrt)
-        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
         self.assertTrue(solution)
-        
+        self.assertEqual(solution.tasks[task_1.name].start, 15)
+        self.assertEqual(solution.tasks[task_1.name].end, 18)
+
+
     def test_double_interval_2(self) -> None:
         pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervalsDoubleInterval2', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
         task_2 = ps.FixedDurationTask('task2', duration = 3)
 
         cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
-                                                 nb_tasks_to_schedule= 1,
-                                                 list_of_time_intervals = [[5, 7], [15, 19]])
+                                                 nb_tasks_to_schedule= 2,
+                                                 list_of_time_intervals = [[5,7], [15, 18]])
         pb.add_constraint(cstrt)
-        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
-        print(solution)
         self.assertTrue(solution)
+
+    def test_triple_interval_1(self) -> None:
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervalsTripleInterval1', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 2,
+                                                 list_of_time_intervals = [[5,7], [11,14], [15, 17]])
+        pb.add_constraint(cstrt)
+        solver = ps.SchedulingSolver(pb)
+        solution = solver.solve()
+        self.assertTrue(solution)
+        print(solution)
 
 
 if __name__ == "__main__":

--- a/test/test_schedule_n_task_in_time_interval.py
+++ b/test/test_schedule_n_task_in_time_interval.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2020-2021 Thomas Paviot (tpaviot@gmail.com)
+#
+# This file is part of ProcessScheduler.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+import processscheduler as ps
+
+class ScheduleNTasksInTimeIntervals(unittest.TestCase):
+    """For each of these tests, we consider two tests: whether the optional task
+    is scheduled or not.
+    """
+    def test_1(self) -> None:
+        """Task can be scheduled."""
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+        task_3 = ps.FixedDurationTask('task3', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2, task_3],
+                                                 nb_tasks_to_schedule= 0,
+                                                 list_of_time_intervals = [[1, 10], [13, 20]])
+        pb.add_constraint(cstrt)
+
+        # Force schedule, otherwise by default it is not scheduled
+        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solution = solver.solve()
+        self.assertTrue(solution)
+        print(solution)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_schedule_n_task_in_time_interval.py
+++ b/test/test_schedule_n_task_in_time_interval.py
@@ -18,7 +18,7 @@ import unittest
 import processscheduler as ps
 
 class ScheduleNTasksInTimeIntervals(unittest.TestCase):
-    def test_1(self) -> None:
+    def test_single_interval_1(self) -> None:
         pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals1', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
         task_2 = ps.FixedDurationTask('task2', duration = 3)
@@ -37,7 +37,7 @@ class ScheduleNTasksInTimeIntervals(unittest.TestCase):
         self.assertTrue(solution.tasks[task_2.name].start == 10)
         self.assertTrue(solution.tasks[task_2.name].end == 13)
 
-    def test_2(self) -> None:
+    def test_single_interval_2(self) -> None:
         pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals2', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
         task_2 = ps.FixedDurationTask('task2', duration = 3)
@@ -54,9 +54,7 @@ class ScheduleNTasksInTimeIntervals(unittest.TestCase):
         self.assertTrue(solution.tasks[task_1.name].end <= 10)
         self.assertTrue(solution.tasks[task_2.name].end <= 10)
 
-
-
-    def test_3(self) -> None:
+    def test_single_interval_3(self) -> None:
         pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals3', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
         task_2 = ps.FixedDurationTask('task2', duration = 3)
@@ -76,7 +74,7 @@ class ScheduleNTasksInTimeIntervals(unittest.TestCase):
         self.assertTrue(solution.tasks[task_1.name].start >= 10)
         self.assertTrue(solution.tasks[task_2.name].end <= 10)
 
-    def test_4(self) -> None:
+    def test_single_interval_4(self) -> None:
         pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals4', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
         task_2 = ps.FixedDurationTask('task2', duration = 3)
@@ -85,9 +83,36 @@ class ScheduleNTasksInTimeIntervals(unittest.TestCase):
                                                  nb_tasks_to_schedule= 3,  # impossible!!
                                                  list_of_time_intervals = [[10, 20]])
         pb.add_constraint(cstrt)
-        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
         self.assertFalse(solution)
+
+    def test_double_interval_1(self) -> None:
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervalsDoubleInterval1', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 2,
+                                                 list_of_time_intervals = [[5, 10], [15, 19]])
+        pb.add_constraint(cstrt)
+        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solution = solver.solve()
+        self.assertTrue(solution)
+        
+    def test_double_interval_2(self) -> None:
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervalsDoubleInterval2', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 1,
+                                                 list_of_time_intervals = [[5, 7], [15, 19]])
+        pb.add_constraint(cstrt)
+        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solution = solver.solve()
+        print(solution)
+        self.assertTrue(solution)
 
 
 if __name__ == "__main__":

--- a/test/test_schedule_n_task_in_time_interval.py
+++ b/test/test_schedule_n_task_in_time_interval.py
@@ -18,26 +18,76 @@ import unittest
 import processscheduler as ps
 
 class ScheduleNTasksInTimeIntervals(unittest.TestCase):
-    """For each of these tests, we consider two tests: whether the optional task
-    is scheduled or not.
-    """
     def test_1(self) -> None:
-        """Task can be scheduled."""
-        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals', horizon=20)
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals1', horizon=20)
         task_1 = ps.FixedDurationTask('task1', duration = 3)
         task_2 = ps.FixedDurationTask('task2', duration = 3)
-        task_3 = ps.FixedDurationTask('task3', duration = 3)
 
-        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2, task_3],
-                                                 nb_tasks_to_schedule= 0,
-                                                 list_of_time_intervals = [[1, 10], [13, 20]])
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 2,
+                                                 list_of_time_intervals = [[10, 13]])
         pb.add_constraint(cstrt)
 
-        # Force schedule, otherwise by default it is not scheduled
-        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
         self.assertTrue(solution)
-        print(solution)
+        # both tasks start and ends at the same time
+        self.assertTrue(solution.tasks[task_1.name].start == 10)
+        self.assertTrue(solution.tasks[task_1.name].end == 13)
+        self.assertTrue(solution.tasks[task_2.name].start == 10)
+        self.assertTrue(solution.tasks[task_2.name].end == 13)
+
+    def test_2(self) -> None:
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals2', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 0,
+                                                 list_of_time_intervals = [[10, 20]])
+        pb.add_constraint(cstrt)
+
+        solver = ps.SchedulingSolver(pb)
+        solution = solver.solve()
+        self.assertTrue(solution)
+        # both tasks are necessarily scheduled before 10
+        self.assertTrue(solution.tasks[task_1.name].end <= 10)
+        self.assertTrue(solution.tasks[task_2.name].end <= 10)
+
+
+
+    def test_3(self) -> None:
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals3', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 1,
+                                                 list_of_time_intervals = [[10, 20]])
+        pb.add_constraint(cstrt)
+        # force task_1 to be shceduled after 10. So the only solution is that task 2 is scheduled
+        # before 10
+        ctr1 = ps.TaskStartAfterLax(task_1, 10)
+
+        solver = ps.SchedulingSolver(pb)
+        solution = solver.solve()
+        self.assertTrue(solution)
+        # both tasks are necessarily scheduled before 10
+        self.assertTrue(solution.tasks[task_1.name].start >= 10)
+        self.assertTrue(solution.tasks[task_2.name].end <= 10)
+
+    def test_4(self) -> None:
+        pb = ps.SchedulingProblem('ScheduleNTasksInTimeIntervals4', horizon=20)
+        task_1 = ps.FixedDurationTask('task1', duration = 3)
+        task_2 = ps.FixedDurationTask('task2', duration = 3)
+
+        cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2],
+                                                 nb_tasks_to_schedule= 3,  # impossible!!
+                                                 list_of_time_intervals = [[10, 20]])
+        pb.add_constraint(cstrt)
+        solver = ps.SchedulingSolver(pb, verbosity=True)
+        solution = solver.solve()
+        self.assertFalse(solution)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@dreinon I started implementing the constraint for n tasks in time intervals. The new constraint name is ``ScheduleNTasksInTimeIntervals``, you can use it with:

```python
cstrt = ps.ScheduleNTasksInTimeIntervals([task_1, task_2, task_3], nb_tasks_to_schedule= 2,
                                          list_of_time_intervals = [[1, 10], [13, 20]])
pb.add_constraint(cstrt)
```
This means the solver will schedule exactly 2 tasks among the list ``[task_1, task_2, task_3]`` in the slots that are given in the list ``list_of_time_intervals``. So far, it does not work as expected: tasks that partially overlap the time intervals are scheduled whereas they should not, I guess it comes from a mistake in the z3 assertion (the ``And`` statement does not prevent such tasks to be scheduled).
