### PR TITLE
First commit for ResourceCapacity constraint

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ copyright = "2020-2021, Thomas Paviot"
 author = "Thomas Paviot"
 
 # The full version, including alpha/beta/rc tags
-version = '0.6.1'
+version = '0.7.0dev'
 release = version
 
 # -- RTD configuration ------------------------------------------------
@@ -63,3 +63,7 @@ else:
     html_theme = "default"
 
 always_document_param_types = True
+
+pygments_style = 'default'
+
+highlight_language = 'autohotkey'

--- a/doc/resource_constraints.rst
+++ b/doc/resource_constraints.rst
@@ -1,11 +1,53 @@
 Resource Constraints
 ====================
 
-ProcessScheduler provides a set of ready-to-use resource constraints. They allow expressing common rules such as "the resource A is available only from 8 am to 12" etc.
+ProcessScheduler provides a set of ready-to-use resource constraints. They allow expressing common rules such as "the resource A is available only from 8 am to 12" etc. There are a set of builtin ready-to-use constraints, listed below.
 
-There are a set of builtin ready-to-use constraints, listed below.
+Capacity
+--------
+The :class:`ResourceCapacity` constraint can be used to restrict the number of tasks which are executed during  certain time periods.
 
-- :class:`AllDifferentWorkers`
+This constraint applies to one resource, whether it is a single worker or a cumulative worker. It takes the time periods as a python dictionary composed of time intervals (the keys) and an integer number (the capacity). The :attr:`kind` parameter allows to define which kind of restriction applies to the resource: exact, atmost (default value) or at least.
+
+.. highlight:: python
+
+.. code-block:: python
+
+    c1 = ps.ResourceCapacity(worker_1, {(0, 6): 2})
+
+In the previous example, the resource :attr:`worker_1` cannot be scheduled into more than 2 timeslots between instants 0 and 6.
+
+Any number of time intervals can be passed to this class, just extend the timeslots dictionary, e.g.:
+
+.. code-block:: python
+
+    c1 = ps.ResourceCapacity(worker_1, {(0, 6): 2,
+                                        (19, 21): 6})
+
+The **restriction** of the :class:`CapacityConstraint` is not necessarily a *limitation*. Indeed you can specify that the integer number is actually an exact of minimal value to target. For example, if we need the resource :attr:`worker_1` to be scheduled **at least** into three time slots between instants 0 and 10, then:
+
+.. code-block:: python
+
+    c1 = ps.ResourceCapacity(worker_1, {(0, 10): 3, kind='atleast'}
+
+ResourceUnavailable
+-------------------
+
+A :class:`ResourceUnavailable` applies to a resource and prevent the solver to schedule this resource during certain time periods. This class takes a list of intervals:
+
+.. code-block:: python
+
+    worker_1 = ps.Worker('Sylvia')
+    ca = ps.ResourceUnavailable(worker_1, [(1,2), (6,8)])
+
+The :const:`ca` instance constraints the resource to be unavailable for 1 period between 1 and 2 instants, and for 2 periods between instants 6 and 8.
+
+.. note::
+
+    This constrint is a special case for the :class:`ResourceCapacity`. The same could be achieved using
+
+AllDifferentWorkers
+-------------------
 
 A :class:`AllDifferentWorkers` constraint applies to two :class:`SelectWorkers` instances. It constraints the solver to select different workers for each :class:`SelectWorkers`. For instance:
 
@@ -22,7 +64,8 @@ could lead the solver to select worker_1 in both cases. Adding the following lin
 
 let the solver selects the worker_1 for s1 and worker_2 for s2 or the opposite, worker_2 for s1 and worker_1 for s2. The cases where worker_1 is selected by both s1 and s2 or worker_2by selected by both s1 and s2 are impossible.
 
-- :class:`AllSameWorkers`
+AllSameWorkers
+--------------
 
 A :class:`AllSameWorkers` constraint applies to two :class:`SelectWorkers` instances. It constraints the solver to ensure both different :class:`SelectWorkers` instances select the same worker. For example:
 
@@ -38,15 +81,3 @@ could lead the solver to select worker_1 for s1 and worker_2 for s2. Adding the 
     cs = ps.AllSametWorkers(s1, s2)
 
 ensures either worker_1 is selected by both s1 and s2, or worker_2 is selected by both s1 and s2.
-
-- :class:`ResourceUnavailable`
-
-A :class:`ResourceUnavailable` applies to a resource and prevent the solver to schedule this resource if it is not available. This class takes a list of intervals:
-
-.. code-block:: python
-
-    worker_1 = ps.Worker('Sylvia')
-    ca = ps.ResourceUnavailable(worker_1, [(1,2), (6,8)])
-
-The :const:`ca` instance constraints the resource to be unavailable for 1 period between 1 and 2 instants, and for 2 periods between instants 6 and 8.
-

--- a/processscheduler/__init__.py
+++ b/processscheduler/__init__.py
@@ -27,7 +27,7 @@ from processscheduler.objective import Indicator, MaximizeObjective, MinimizeObj
 from processscheduler.task import ZeroDurationTask, FixedDurationTask, VariableDurationTask
 from processscheduler.task_constraint import *
 from processscheduler.resource_constraint import (AllSameSelected, AllDifferentSelected,
-	                                              ResourceUnavailable)
+	                                              ResourceUnavailable, ResourceCapacity)
 from processscheduler.resource import Worker, CumulativeWorker, SelectWorkers
 from processscheduler.problem import SchedulingProblem
 from processscheduler.solver import SchedulingSolver

--- a/processscheduler/resource_constraint.py
+++ b/processscheduler/resource_constraint.py
@@ -18,9 +18,8 @@
 from typing import Optional
 import uuid
 
-from z3 import And, Bool, Implies, Int, Not, Sum, Xor
+from z3 import And, Implies, Int, Sum, Xor
 
-from processscheduler.task import UnavailabilityTask
 from processscheduler.resource import Worker, CumulativeWorker
 from processscheduler.base import _Constraint
 
@@ -29,26 +28,28 @@ class ResourceCapacity(_Constraint):
     """ set a mini/maxi/exact number of slots a resource can be scheduled."""
     def __init__(self, resource,
                        dict_time_intervals_limits,
-                       kind: Optional[str] = 'exact',
+                       kind: Optional[str] = 'atmost',
                        optional: Optional[bool] = False) -> None:
         """The resource can be a single Worker or a CumulativeWorker.
 
         The list of time_intervals is a dict such as:
         [(1,20):6, (50,60):2] which means: in the interval (1,20), the resource might not use
         more than 6 slots. And no more than 2 time slots in the interval (50, 60)
+
+        kind: optional string, default to 'atmost', can be 'atleast' or 'exact'
         """
         super().__init__()
 
         self.optional = optional
 
-        #problem_function = {'atleast': PbGe, 'atmost': PbLe, 'exact': PbEq}
+        if kind not in ['exact', 'atmost', 'atleast']:
+            raise ValueError("kind must either be 'exact', 'atleast' or 'atmost'")
 
         if isinstance(resource, Worker):
             workers = [resource]
         elif isinstance(resource, CumulativeWorker):
             workers = resource.cumulative_workers
 
-        all_bools =[]
         for worker in workers:
             # for this task, the logic expression is that any of its start or end must be
             # between two consecutive intervals
@@ -75,7 +76,7 @@ class ResourceCapacity(_Constraint):
                                         end_task_i > upper_bound),
                                     dur == upper_bound - start_task_i)
                     self.set_applied_not_applied_assertions(asst3)
-                    # # all overlap
+                    # all overlap
                     asst4 = Implies(And(start_task_i < lower_bound,
                                         end_task_i > upper_bound),
                                     dur == upper_bound - lower_bound)
@@ -83,7 +84,15 @@ class ResourceCapacity(_Constraint):
 
                     durations.append(dur)
 
-                self.set_applied_not_applied_assertions(Sum(durations) <= number_of_time_slots)
+                # capacity constraint depends on the kind
+                if kind == 'exact':
+                    capa_constrt = Sum(durations) == number_of_time_slots
+                elif kind == 'atmost':
+                    capa_constrt = Sum(durations) <= number_of_time_slots
+                elif kind == 'atleast':
+                    capa_constrt = Sum(durations) >= number_of_time_slots
+
+                self.set_applied_not_applied_assertions(capa_constrt)
 
 
 class ResourceUnavailable(_Constraint):
@@ -100,6 +109,9 @@ class ResourceUnavailable(_Constraint):
         for example [(0, 2), (5, 8)]
         """
         super().__init__()
+
+        self.optional = optional
+
         # for each interval we create a task 'UnavailableResource%i'
         if isinstance(resource, Worker):
             workers = [resource]

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -219,7 +219,8 @@ class SchedulingSolver:
                 if resource_is_assigned and (req_res.name not in new_task_solution.assigned_resources):
                     # if it is a cumulative resource, then we transform the resource name
                     resource_name = req_res.name.split('_CumulativeWorker_')[0]
-                    new_task_solution.assigned_resources.append(resource_name)
+                    if not resource_name in new_task_solution.assigned_resources:
+                        new_task_solution.assigned_resources.append(resource_name)
 
             solution.add_task_solution(new_task_solution)
 
@@ -242,7 +243,7 @@ class SchedulingSolver:
                 st_var, end_var = resource.busy_intervals[task]
                 start = z3_sol[st_var].as_long()
                 end = z3_sol[end_var].as_long()
-                if start >= 0 and end >= 0:
+                if start >= 0 and end >= 0 and (task_name, start, end) not in new_resource_solution.assignments:
                     new_resource_solution.assignments.append((task_name, start, end))
 
             if '_CumulativeWorker_' in resource.name:

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -284,7 +284,7 @@ class SchedulingSolver:
             for decl in solution.decls():
                 var_name = decl.name()
                 var_value = solution[decl]
-                print("\t%s=%s" %(var_name, var_value))
+                print("\t-> %s=%s" %(var_name, var_value))
 
         sol = self.build_solution(solution)
 

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -277,18 +277,26 @@ class SchedulingSolver:
                 print('\t\t->%s: %s' % (objective_name, objective_value.value()))
 
         if self.debug:
-            print('Solver satistics:')
-            for key, value in self._solver.statistics():
-                print('\t%s: %s' % (key, value))
-            print('Solution:')
-            for decl in solution.decls():
-                var_name = decl.name()
-                var_value = solution[decl]
-                print("\t-> %s=%s" %(var_name, var_value))
+            self.print_statistics()
+            self.print_solution()
 
         sol = self.build_solution(solution)
 
         return sol
+
+    def print_statistics(self):
+        """A utility method that displays solver statistics"""
+        print('Solver satistics:')
+        for key, value in self._solver.statistics():
+            print('\t%s: %s' % (key, value))
+
+    def print_solution(self):
+        """A utility method that displays all internal variables for the current solution"""
+        print('Solution:')
+        for decl in self.current_solution.decls():
+            var_name = decl.name()
+            var_value = self.current_solution[decl]
+            print("\t-> %s=%s" %(var_name, var_value))
 
     def find_another_solution(self, variable: ArithRef) -> bool:
         """ let the solver find another solution for the variable """

--- a/test/test_capacity.py
+++ b/test/test_capacity.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import unittest
 
 import processscheduler as ps
@@ -29,17 +28,17 @@ class TestCapacity(unittest.TestCase):
         c1 = ps.ResourceCapacity(worker_1, {(0, 6): 2})
         pb.add_constraint(c1)
 
-        solver = ps.SchedulingSolver(pb, debug=True)
+        solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
         self.assertTrue(solution)
         # the only possible solution is that the task is scheduled form 4 to 12
         self.assertEqual(solution.tasks[task_1.name].start, 4)
-        self.assertEqual(solution.tasks[task_2.name].end, 12)
+        self.assertEqual(solution.tasks[task_1.name].end, 12)
 
-    def test_resource_capacity_1(self) -> None:
+    def test_resource_capacity_2(self) -> None:
         # same problem, but we force two tasks to be scheduled at start and end
         # of the planning
-        pb = ps.SchedulingProblem('ResourceCapacity1', horizon=12)
+        pb = ps.SchedulingProblem('ResourceCapacity2', horizon=12)
         task_1 = ps.FixedDurationTask('task1', duration = 4)
         task_2 = ps.FixedDurationTask('task2', duration = 4)
         worker_1 = ps.Worker('Worker1')
@@ -52,7 +51,7 @@ class TestCapacity(unittest.TestCase):
         solver = ps.SchedulingSolver(pb)
         solution = solver.solve()
         self.assertTrue(solution)
-            # there should be one task from 0 to 4 and one task from 8 to 12.
+        # there should be one task from 0 to 4 and one task from 8 to 12.
         self.assertTrue(solution.tasks[task_1.name].start == 0 or solution.tasks[task_2.name].start == 0)
         self.assertTrue(solution.tasks[task_1.name].start == 8 or solution.tasks[task_2.name].start == 8)
 

--- a/test/test_capacity.py
+++ b/test/test_capacity.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2020-2021 Thomas Paviot (tpaviot@gmail.com)
+#
+# This file is part of ProcessScheduler.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+import processscheduler as ps
+
+class TestCapacity(unittest.TestCase):
+    def test_resource_capacity_1(self) -> None:
+        pb = ps.SchedulingProblem('ResourceCapacity1', horizon=12)
+        task_1 = ps.FixedDurationTask('task1', duration = 8)
+
+        worker_1 = ps.Worker('Worker1')
+        task_1.add_required_resource(worker_1)
+
+        c1 = ps.ResourceCapacity(worker_1, {(0, 6): 2})
+        pb.add_constraint(c1)
+
+        solver = ps.SchedulingSolver(pb, debug=True)
+        solution = solver.solve()
+        self.assertTrue(solution)
+        # the only possible solution is that the task is scheduled form 4 to 12
+        self.assertEqual(solution.tasks[task_1.name].start, 4)
+        self.assertEqual(solution.tasks[task_2.name].end, 12)
+
+    def test_resource_capacity_1(self) -> None:
+        # same problem, but we force two tasks to be scheduled at start and end
+        # of the planning
+        pb = ps.SchedulingProblem('ResourceCapacity1', horizon=12)
+        task_1 = ps.FixedDurationTask('task1', duration = 4)
+        task_2 = ps.FixedDurationTask('task2', duration = 4)
+        worker_1 = ps.Worker('Worker1')
+        task_1.add_required_resource(worker_1)
+        task_2.add_required_resource(worker_1)
+
+        c1 = ps.ResourceCapacity(worker_1, {(4, 8): 0})
+        pb.add_constraint(c1)
+
+        solver = ps.SchedulingSolver(pb)
+        solution = solver.solve()
+        self.assertTrue(solution)
+            # there should be one task from 0 to 4 and one task from 8 to 12.
+        self.assertTrue(solution.tasks[task_1.name].start == 0 or solution.tasks[task_2.name].start == 0)
+        self.assertTrue(solution.tasks[task_1.name].start == 8 or solution.tasks[task_2.name].start == 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This branch adds a new ResourceCapacity constraint:

```python
c1 = ps.ResourceCapacity(worker_1, {(4, 8): 0, (10, 42): 4})
```
means that the resource worker_1 cannot be used between 4 and 8, and can be used at most for 4 timeslots between 10 and 42.

ping @dreinon 
