### PR TITLE
Add html output for plotly

### DIFF
--- a/processscheduler/solution.py
+++ b/processscheduler/solution.py
@@ -128,7 +128,8 @@ class SchedulingSolution:
                             show_plot: Optional[bool] = True,
                             show_indicators: Optional[bool] = True,
                             render_mode: Optional[str] = 'Resource',
-                            fig_filename: Optional[str] = None,) -> None:
+                            fig_filename: Optional[str] = None,
+                            html_filename: Optional[str] = None,) -> None:
         """Use plotly.create_gantt method, see
         https://plotly.github.io/plotly.py-docs/generated/plotly.figure_factory.create_gantt.html
         """
@@ -175,6 +176,9 @@ class SchedulingSolution:
 
         if fig_filename is not None:
             fig.write_image(fig_filename)
+
+        if html_filename is not None:
+            print(fig.to_html())
 
         if show_plot:
             fig.show()

--- a/processscheduler/solution.py
+++ b/processscheduler/solution.py
@@ -17,6 +17,7 @@
 
 from datetime import time, timedelta, datetime
 import json
+from pathlib import Path
 
 from typing import Optional, Tuple
 
@@ -178,7 +179,8 @@ class SchedulingSolution:
             fig.write_image(fig_filename)
 
         if html_filename is not None:
-            print(fig.to_html())
+            file = Path(html_filename)
+            file.write_text(fig.to_html(include_plotlyjs='cdn'))
 
         if show_plot:
             fig.show()

--- a/test/test_gantt.py
+++ b/test/test_gantt.py
@@ -154,8 +154,16 @@ class TestGantt(unittest.TestCase):
         solution.render_gantt_plotly(render_mode='Task',
                                      show_plot=False,
                                      fig_filename='test_render_tasks_plotly.svg')
+        solution.render_gantt_plotly(render_mode='Resource',
+                                     show_plot=False,
+                                     html_filename='test_render_resources_plotly.html')
+        solution.render_gantt_plotly(render_mode='Task',
+                                     show_plot=False,
+                                     html_filename='test_render_tasks_plotly.html')
         self.assertTrue(os.path.isfile('test_render_resources_plotly.svg'))
         self.assertTrue(os.path.isfile('test_render_tasks_plotly.svg'))
+        self.assertTrue(os.path.isfile('test_render_resources_plotly.html'))
+        self.assertTrue(os.path.isfile('test_render_tasks_plotly.html'))
 
 
     def test_gantt_plotly_with_indicators_figsize(self):


### PR DESCRIPTION
Added an optional parameter for plotly output to create an HTML file. matplotlib does not have this same capability to output to html.