### PR TITLE
Add sorted options for Plotly

### DIFF
--- a/doc/solving.rst
+++ b/doc/solving.rst
@@ -108,4 +108,13 @@ Call the :func:`render_gantt_matplotlib` to render the solution as a Gantt chart
         # a second gantt chart, in 'Task' mode
         solution.render_gantt_matplotlib(render_mode='Task')
 
-If you prefer **plotly**, just use the method name :func:`render_gantt_plotly`. Both methods have the same signature, so you can just switch from one to the other by replacing the method names. However, take care that plotly rendering needs **real timepoints** (set at least :attr:`delta_time` at the problem creation).
+Call the :func:`render_gantt_plotly` to render the solution as a Gantt chart using **plotly**.
+Take care that plotly rendering needs **real timepoints** (set at least :attr:`delta_time` at the problem creation).
+
+. code-block:: python
+
+    solution = solver.solve()
+    if solution is not None:
+        solution.render_gantt_plotly(sort="Start", html_filename="index.html")  # default render_mode is 'Resource'
+        # a second gantt chart, in 'Task' mode
+        solution.render_gantt_plotly(render_mode='Task')

--- a/processscheduler/solution.py
+++ b/processscheduler/solution.py
@@ -173,11 +173,13 @@ class SchedulingSolution:
         for _ in range(len(df)):
             colors.append('#%02X%02X%02X' % (r(), r(), r()))
 
-        if sort in ["Task", "Resource"]:
-            df = sorted(df, key = lambda i: i[sort],reverse=False)
-
-        if sort in ["Start", "Finish"]:
-            df = sorted(df, key = lambda i: i[sort],reverse=True)
+        if sort is not None:
+            if sort in ["Task", "Resource"]:
+                df = sorted(df, key = lambda i: i[sort],reverse=False)
+            elif sort in ["Start", "Finish"]:
+                df = sorted(df, key = lambda i: i[sort],reverse=True)
+            else:
+                raise ValueError('sort must be either "Task", "Resource", "Start", or "Finish"')
 
         if fig_size is None:
             fig = create_gantt(df, colors=colors, index_col=render_mode, show_colorbar=True, showgrid_x=True,

--- a/processscheduler/solution.py
+++ b/processscheduler/solution.py
@@ -130,6 +130,7 @@ class SchedulingSolution:
                             show_plot: Optional[bool] = True,
                             show_indicators: Optional[bool] = True,
                             render_mode: Optional[str] = 'Resource',
+                            sort: Optional[str] = None,
                             fig_filename: Optional[str] = None,
                             html_filename: Optional[str] = None,) -> None:
         """Use plotly.create_gantt method, see
@@ -171,6 +172,12 @@ class SchedulingSolution:
         colors = []
         for _ in range(len(df)):
             colors.append('#%02X%02X%02X' % (r(), r(), r()))
+
+        if sort in ["Task", "Resource"]:
+            df = sorted(df, key = lambda i: i[sort],reverse=False)
+
+        if sort in ["Start", "Finish"]:
+            df = sorted(df, key = lambda i: i[sort],reverse=True)
 
         if fig_size is None:
             fig = create_gantt(df, colors=colors, index_col=render_mode, show_colorbar=True, showgrid_x=True,

--- a/test/test_gantt.py
+++ b/test/test_gantt.py
@@ -150,15 +150,19 @@ class TestGantt(unittest.TestCase):
         # display solution, using both ascii or matplotlib
         solution.render_gantt_plotly(render_mode='Resource',
                                      show_plot=False,
+                                     sort='Resource',
                                      fig_filename='test_render_resources_plotly.svg')
         solution.render_gantt_plotly(render_mode='Task',
                                      show_plot=False,
+                                     sort='Task',
                                      fig_filename='test_render_tasks_plotly.svg')
         solution.render_gantt_plotly(render_mode='Resource',
                                      show_plot=False,
+                                     sort='Start',
                                      html_filename='test_render_resources_plotly.html')
         solution.render_gantt_plotly(render_mode='Task',
                                      show_plot=False,
+                                     sort='Finish',
                                      html_filename='test_render_tasks_plotly.html')
         self.assertTrue(os.path.isfile('test_render_resources_plotly.svg'))
         self.assertTrue(os.path.isfile('test_render_tasks_plotly.svg'))


### PR DESCRIPTION
I found the output gantt to be sorted (in reverse direction) by the way the tasks were entered. Adding this to the plotly output was fairly straightforward. I'm trying to decipher how to add it to matplotlib output as well. I thought I would ship this as it is working and matplotlib can be addressed in a subsequent PR.