### PR TITLE
Multi to single optimization objective

### DIFF
--- a/processscheduler/objective.py
+++ b/processscheduler/objective.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 from z3 import Int, BoolRef, ArithRef
 
 from processscheduler.base import _NamedUIDObject
@@ -40,13 +40,6 @@ class Indicator(_NamedUIDObject):
 
         ps_context.main_context.add_indicator(self)
 
-class BuiltinIndicator(_NamedUIDObject):
-    """ a set of builtin objectives """
-    def __init__(self, name:str) -> None:
-        super().__init__(name)
-
-        ps_context.main_context.add_indicator(self)
-
 class Objective(_NamedUIDObject):
     def __init__(self, name:str, target: Union[ArithRef, Indicator]) -> None:
         super().__init__(name)
@@ -60,9 +53,11 @@ class Objective(_NamedUIDObject):
         ps_context.main_context.add_objective(self)
 
 class MaximizeObjective(Objective):
-    def __init__(self, name:str, target: Union[ArithRef, Indicator]) -> None:
+    def __init__(self, name:str, target: Union[ArithRef, Indicator], weight: Optional[int] = 1) -> None:
         super().__init__(name, target)
+        self.weight = weight
 
 class MinimizeObjective(Objective):
-    def __init__(self, name:str, target: Union[ArithRef, Indicator]) -> None:
+    def __init__(self, name:str, target: Union[ArithRef, Indicator], weight: Optional[int] = 1) -> None:
         super().__init__(name, target)
+        self.weight = 1

--- a/processscheduler/objective.py
+++ b/processscheduler/objective.py
@@ -60,4 +60,4 @@ class MaximizeObjective(Objective):
 class MinimizeObjective(Objective):
     def __init__(self, name:str, target: Union[ArithRef, Indicator], weight: Optional[int] = 1) -> None:
         super().__init__(name, target)
-        self.weight = 1
+        self.weight = weight

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -22,9 +22,9 @@ from typing import Optional
 import uuid
 import warnings
 
-from z3 import Solver, SolverFor, Sum, unsat, sat, ArithRef, unknown, Optimize, set_option, Or
+from z3 import Int, Solver, SolverFor, Sum, unsat, sat, ArithRef, unknown, set_option, Or
 
-from processscheduler.objective import MaximizeObjective, MinimizeObjective
+from processscheduler.objective import MaximizeObjective, MinimizeObjective, Indicator
 from processscheduler.solution import SchedulingSolution, TaskSolution, ResourceSolution
 
 #
@@ -39,7 +39,8 @@ class SchedulingSolver:
                  parallel: Optional[bool] = False,
                  random_seed = False,
                  logics=None,
-                 verbosity=0):
+                 verbosity=0,
+                 multi_objective_to_single: Optional[bool] = True):
         """ Scheduling Solver
 
         debug: True or False, False by default
@@ -52,7 +53,8 @@ class SchedulingSolver:
         self.debug = debug
         # objectives list
         self.optimize_priority = optimize_priority
-        self.objectives = []  # the list of all objectives defined in this problem
+        self.multi_objective_to_single = multi_objective_to_single
+        self.objective= None  # the list of all objectives defined in this problem
 
         if debug:
             set_option("verbose", 2)
@@ -75,29 +77,24 @@ class SchedulingSolver:
 
         # check if the problem is an optimization problem
         self.is_not_optimization_problem = len(self.problem_context.objectives) == 0
+        self.is_optimization_problem = len(self.problem_context.objectives) > 0
         self.is_multi_objective_optimization_problem = len(self.problem_context.objectives) > 1
-        self.is_single_objective_optimization_problem = len(self.problem_context.objectives) == 1
-
         # the Optimize() solver is used only in the case of a mutli-optimization
         # problem. This enables to choose the priority method.
         # in the case of a single objective optimization, the Optimize() solver
         # apperas to be less robust than the basic Solver(). The
         # incremental solver is then used.
-        if self.is_multi_objective_optimization_problem:
-            self._solver = Optimize()  # Solver with optimization
-            self._solver.set(priority=self.optimize_priority)
-            print("\t-> Solver with optimization enabled")
+    
+        # see this url for a documentation about logics
+        # http://smtlib.cs.uiowa.edu/logics.shtml
+        if logics is None:
+            self._solver = Solver()
+            print("\t-> Standard SAT/SMT solver")
         else:
-            # see this url for a documentation about logics
-            # http://smtlib.cs.uiowa.edu/logics.shtml
-            if logics is None:
-                self._solver = Solver()
-                print("\t-> Standard SAT/SMT solver")
-            else:
-                self._solver = SolverFor(logics)
-                print("\t-> SMT solver using logics", logics)
-            if debug:
-                set_option(unsat_core=True)
+            self._solver = SolverFor(logics)
+            print("\t-> SMT solver using logics", logics)
+        if debug:
+            set_option(unsat_core=True)
 
         if parallel:
             set_option("parallel.enable", True)  # enable parallel computation
@@ -128,15 +125,14 @@ class SchedulingSolver:
                     start_task_k, end_task_k = busy_intervals[k]
                     self.add_constraint(Or(start_task_k >= end_task_i, start_task_i >= end_task_k))
 
-
         # process indicators
         for indic in self.problem_context.indicators:
             self.add_constraint(indic.get_assertions())
 
         self.process_work_amount()
 
-        if self.is_multi_objective_optimization_problem:
-            self.create_objectives()
+        if self.is_optimization_problem:
+            self.create_objective()
 
         # each time the solver is called, the current_solution is stored
         self.current_solution = None
@@ -154,18 +150,26 @@ class SchedulingSolver:
         else:
             self._solver.add(cstr)
 
-    def create_objectives(self) -> None:
+    def create_objective(self) -> bool:
         """ create optimization objectives """
         # in case of a single value to optimize
-        for obj in self.problem_context.objectives:
-            if isinstance(obj, MaximizeObjective):
-                # look for the minimum horizon, i.e. the shortest
-                # time horizon to complete all tasks
-                new_max = self._solver.maximize(obj.target)
-                self.objectives.append(['%s(max objective)' % obj.target, new_max])
-            elif isinstance(obj, MinimizeObjective):
-                new_min = self._solver.minimize(obj.target)
-                self.objectives.append(['%s(min objective)' % obj.target, new_min])
+        if self.is_multi_objective_optimization_problem:
+            # Replace objectives O_i, O_j, O_k with
+            # O = WiOi+WjOj+WkOk etc.
+            equivalent_single_objective = Int("EquivalentSingleObjective")
+            weighted_objectives = []
+            weight = 1
+            for obj in self.problem_context.objectives:
+                weighted_objectives.append(1 * obj.target)
+            self.add_constraint(equivalent_single_objective == Sum(weighted_objectives))
+            # create an indicator
+            equivalent_indicator = Indicator('EquivalentIndicator',
+                                              equivalent_single_objective)
+            print(equivalent_single_objective)
+            self.objective = MinimizeObjective("EquivalentObjective", equivalent_indicator)
+            self.add_constraint(equivalent_indicator.get_assertions())
+        else:
+            self.objective = self._problem.context.objectives[0]
 
     def process_work_amount(self) -> None:
         """ for each task, compute the total work for all required resources """
@@ -296,16 +300,15 @@ class SchedulingSolver:
         if self.debug:
             self.print_assertions()
 
-        if self.is_single_objective_optimization_problem:
+        if self.is_optimization_problem:
             # in this case, use the incremental solver
-            objective = self.problem_context.objectives[0]
-            if isinstance(objective, MinimizeObjective):
+            if isinstance(self.objective, MinimizeObjective):
                 dd = 'min'
-            elif isinstance(objective, MaximizeObjective):
+            elif isinstance(self.objective, MaximizeObjective):
                 dd = 'max'
             # print(dir(objective))
             # print(objective.target)
-            solution = self.solve_optimize_incremental(objective.target, kind=dd)
+            solution = self.solve_optimize_incremental(self.objective.target, kind=dd)
             if not solution:
                 #raise ('No Solution')
                 return False
@@ -334,7 +337,7 @@ class SchedulingSolver:
             # then get the solution
             solution = self._solver.model()
 
-            if self.objectives:
+            if self.objective:
                 print('Optimization results:\n=====================')
                 print('\t->Objective priority specification: %s' % self.optimize_priority)
                 print('\t->Objective values:')

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -51,7 +51,7 @@ class SchedulingSolver:
         # objectives list
         self.multi_objective_to_single = multi_objective_to_single
         self.objective= None  # the list of all objectives defined in this problem
-
+        # set_option('smt.arith.auto_config_simplex', True)
         if debug:
             set_option("verbose", 2)
         else:
@@ -92,6 +92,9 @@ class SchedulingSolver:
         if debug:
             set_option(unsat_core=True)
 
+        # self._solver.set("sat.cardinality.solver", True)
+        # self._solver.set("sat.core.minimize", True)
+        # self._solver.set("sat.core.minimize_partial", True)
         if parallel:
             set_option("parallel.enable", True)  # enable parallel computation
 

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -35,7 +35,6 @@ class SchedulingSolver:
     def __init__(self, problem,
                  debug: Optional[bool] = False,
                  max_time: Optional[int] = 10,
-                 optimize_priority = 'lex',
                  parallel: Optional[bool] = False,
                  random_seed = False,
                  logics=None,
@@ -45,14 +44,12 @@ class SchedulingSolver:
 
         debug: True or False, False by default
         max_time: time in seconds, 60 by default
-        optimize_priority: one of 'lex', 'box', 'pareto'
         parallel: True to enable mutlthreading, False by default
         """
         self._problem = problem
         self.problem_context = problem.context
         self.debug = debug
         # objectives list
-        self.optimize_priority = optimize_priority
         self.multi_objective_to_single = multi_objective_to_single
         self.objective= None  # the list of all objectives defined in this problem
 
@@ -339,7 +336,6 @@ class SchedulingSolver:
 
             if self.objective:
                 print('Optimization results:\n=====================')
-                print('\t->Objective priority specification: %s' % self.optimize_priority)
                 print('\t->Objective values:')
                 for objective_name, objective_value in self.objectives:  # if ever no objectives, this line will do nothing
                     print('\t\t->%s: %s' % (objective_name, objective_value.value()))

--- a/test/test_indicator.py
+++ b/test/test_indicator.py
@@ -114,7 +114,7 @@ class TestIndicator(unittest.TestCase):
     # def test_resource_utilization_indicator_5(self) -> None:
     #     """Same input data than previous tests, but we dont use
     #     an optimisation solver, the objective of 100% is set by an
-    #     additionnal constraint. This should be **much faster**."""
+    #     additional constraint. This should be **much faster**."""
     #     problem = ps.SchedulingProblem('IndicatorUtilization5', horizon = 20)
 
     #     worker = ps.Worker('Worker')

--- a/test/test_indicator.py
+++ b/test/test_indicator.py
@@ -147,7 +147,6 @@ class TestIndicator(unittest.TestCase):
         problem.add_objective_priorities()
 
         solver = ps.SchedulingSolver(problem)
-        solver._solver.set(priority='pareto')
         solution = solver.solve()
         self.assertTrue(solution)
 

--- a/test/test_multiple_objectives.py
+++ b/test/test_multiple_objectives.py
@@ -59,48 +59,48 @@ class MultiObjective(unittest.TestCase):
         self.assertEqual(solution.tasks[task_1.name].start, 0)
         self.assertEqual(solution.tasks[task_2.name].end, 20)
 
-    def test_multi_two_tasks_box(self) -> None:
-        # in the thrid test, optimize both. What will the result be?
-        pb = ps.SchedulingProblem('MultiObjective2', horizon=20)
-        task_1 = ps.FixedDurationTask('task1', duration = 3)
-        task_2 = ps.FixedDurationTask('task2', duration = 3)
+    # def test_multi_two_tasks_box(self) -> None:
+    #     # in the thrid test, optimize both. What will the result be?
+    #     pb = ps.SchedulingProblem('MultiObjective2', horizon=20)
+    #     task_1 = ps.FixedDurationTask('task1', duration = 3)
+    #     task_2 = ps.FixedDurationTask('task2', duration = 3)
 
-        pb.add_constraint(task_1.end == 20 - task_2.start)
+    #     pb.add_constraint(task_1.end == 20 - task_2.start)
 
-        ind_1 = ps.Indicator('Task1End', task_1.end)
-        ind_2 = ps.Indicator('Task2End', task_2.end)
+    #     ind_1 = ps.Indicator('Task1End', task_1.end)
+    #     ind_2 = ps.Indicator('Task2End', task_2.end)
 
-        pb.maximize_indicator(ind_1)
-        pb.maximize_indicator(ind_2)
+    #     pb.maximize_indicator(ind_1)
+    #     pb.maximize_indicator(ind_2)
 
-        # the solution depend on the algorithm
-        # by default, maximize the first objective, then maximize the second one while keeping
-        # the first one fixed
-        solution1 = ps.SchedulingSolver(pb, optimize_priority='box').solve()
-        self.assertTrue(solution1)
+    #     # the solution depend on the algorithm
+    #     # by default, maximize the first objective, then maximize the second one while keeping
+    #     # the first one fixed
+    #     solution1 = ps.SchedulingSolver(pb, optimize_priority='box').solve()
+    #     self.assertTrue(solution1)
 
-    def test_multi_two_tasks_pareto(self) -> None:
-        # in the thrid test, optimize both. What will the result be?
-        pb = ps.SchedulingProblem('MultiObjective2', horizon=20)
-        task_1 = ps.FixedDurationTask('task1', duration = 3)
-        task_2 = ps.FixedDurationTask('task2', duration = 3)
+    # def test_multi_two_tasks_pareto(self) -> None:
+    #     # in the thrid test, optimize both. What will the result be?
+    #     pb = ps.SchedulingProblem('MultiObjective2', horizon=20)
+    #     task_1 = ps.FixedDurationTask('task1', duration = 3)
+    #     task_2 = ps.FixedDurationTask('task2', duration = 3)
 
-        pb.add_constraint(task_1.end == 20 - task_2.start)
+    #     pb.add_constraint(task_1.end == 20 - task_2.start)
 
-        ind_1 = ps.Indicator('Task1End', task_1.end)
-        ind_2 = ps.Indicator('Task2End', task_2.end)
+    #     ind_1 = ps.Indicator('Task1End', task_1.end)
+    #     ind_2 = ps.Indicator('Task2End', task_2.end)
 
-        pb.maximize_indicator(ind_1)
-        pb.maximize_indicator(ind_2)
+    #     pb.maximize_indicator(ind_1)
+    #     pb.maximize_indicator(ind_2)
 
-        # the solution depend on the algorithm
-        # by default, maximize the first objective, then maximize the second one while keeping
-        # the first one fixed
-        solver = ps.SchedulingSolver(pb, optimize_priority='pareto')
-        i = 0
-        while solver.solve():
-            i += 1
-        self.assertEqual(i, 18)
+    #     # the solution depend on the algorithm
+    #     # by default, maximize the first objective, then maximize the second one while keeping
+    #     # the first one fixed
+    #     solver = ps.SchedulingSolver(pb, optimize_priority='pareto')
+    #     i = 0
+    #     while solver.solve():
+    #         i += 1
+    #     self.assertEqual(i, 18)
 
 
 if __name__ == "__main__":

--- a/test/test_multiple_objectives.py
+++ b/test/test_multiple_objectives.py
@@ -59,49 +59,6 @@ class MultiObjective(unittest.TestCase):
         self.assertEqual(solution.tasks[task_1.name].start, 0)
         self.assertEqual(solution.tasks[task_2.name].end, 20)
 
-    # def test_multi_two_tasks_box(self) -> None:
-    #     # in the thrid test, optimize both. What will the result be?
-    #     pb = ps.SchedulingProblem('MultiObjective2', horizon=20)
-    #     task_1 = ps.FixedDurationTask('task1', duration = 3)
-    #     task_2 = ps.FixedDurationTask('task2', duration = 3)
-
-    #     pb.add_constraint(task_1.end == 20 - task_2.start)
-
-    #     ind_1 = ps.Indicator('Task1End', task_1.end)
-    #     ind_2 = ps.Indicator('Task2End', task_2.end)
-
-    #     pb.maximize_indicator(ind_1)
-    #     pb.maximize_indicator(ind_2)
-
-    #     # the solution depend on the algorithm
-    #     # by default, maximize the first objective, then maximize the second one while keeping
-    #     # the first one fixed
-    #     solution1 = ps.SchedulingSolver(pb, optimize_priority='box').solve()
-    #     self.assertTrue(solution1)
-
-    # def test_multi_two_tasks_pareto(self) -> None:
-    #     # in the thrid test, optimize both. What will the result be?
-    #     pb = ps.SchedulingProblem('MultiObjective2', horizon=20)
-    #     task_1 = ps.FixedDurationTask('task1', duration = 3)
-    #     task_2 = ps.FixedDurationTask('task2', duration = 3)
-
-    #     pb.add_constraint(task_1.end == 20 - task_2.start)
-
-    #     ind_1 = ps.Indicator('Task1End', task_1.end)
-    #     ind_2 = ps.Indicator('Task2End', task_2.end)
-
-    #     pb.maximize_indicator(ind_1)
-    #     pb.maximize_indicator(ind_2)
-
-    #     # the solution depend on the algorithm
-    #     # by default, maximize the first objective, then maximize the second one while keeping
-    #     # the first one fixed
-    #     solver = ps.SchedulingSolver(pb, optimize_priority='pareto')
-    #     i = 0
-    #     while solver.solve():
-    #         i += 1
-    #     self.assertEqual(i, 18)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR introduces an API change.

An objective has now a weight. These weights are taken into consideration only in the case of multiobjective problems.

```python
digital_transformation.add_objective_priorities(weight=1)
digital_transformation.add_objective_makespan(weight=10)
```

The multiobjective problem is turned into a single objective and use the incremental solver. The default z3 optimization is not used anymore.

Use the "QF_IDL" logics wherever you can.

ping @magic7s
