### PR TITLE
Add tests output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ MANIFEST
 .coverage
 .pytype/
 .vscode/
+
+# test outputs
+test_*.svg
+test_*.html
+*.smt2


### PR DESCRIPTION
@tpaviot Note that .gitignore file seems to have 40 lines with no empty blank line at the bottom, but it actually does have 41 with the empty one, it's just that GH doesn't show it (you can try to edit the file and you'll see 41).