### PR TITLE
Bound solver and return indicator in objectives

### DIFF
--- a/processscheduler/objective.py
+++ b/processscheduler/objective.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 from z3 import Int, BoolRef, ArithRef
 
 from processscheduler.base import _NamedUIDObject
@@ -24,7 +24,8 @@ import processscheduler.context as ps_context
 class Indicator(_NamedUIDObject):
     """ an performance indicator, can be evaluated after the solver has finished solving,
     or being optimized (Max or Min) *before* calling the solver. """
-    def __init__(self, name: str, expression: Union[BoolRef, ArithRef]) -> None:
+    def __init__(self, name: str, expression: Union[BoolRef, ArithRef],
+                 bounds: Optional[Tuple[Optional[int]]] = None) -> None:
         super().__init__(name)
         # scheduled start, end and duration set to 0 by default
         # be set after the solver is called
@@ -35,6 +36,12 @@ class Indicator(_NamedUIDObject):
         # by default the scheduled value is set to None
         # set by the solver
         self.scheduled_value = None
+
+        # -- Bound --
+        # None if not bounded
+        # (lower_bound, None), (None, upper_bound) if only one-side bounded
+        # (lower_bound, upper_bound) if full bounded
+        self.bounds = bounds
 
         self.add_assertion(self.indicator_variable == expression)
 
@@ -47,9 +54,10 @@ class Objective(_NamedUIDObject):
             raise TypeError('the indicator expression must be either a BoolRef, ArithRef or Indicator instance.')
         if isinstance(target, Indicator):
             self.target = target.indicator_variable
+            self.bounds = target.bounds
         else:
             self.target = target
-
+            self.bounds = None
         ps_context.main_context.add_objective(self)
 
 class MaximizeObjective(Objective):

--- a/processscheduler/solver.py
+++ b/processscheduler/solver.py
@@ -382,6 +382,11 @@ class SchedulingSolver:
         print('Incremental optimizer:\n======================')
         three_last_times = []
 
+        if self.objective.bounds is None:
+            bound = None
+        else:
+            bound = self.objective.bounds[0] if kind == 'min' else self.objective.bounds[1]
+
         while True:  # infinite loop, break if unsat of max_depth
             depth += 1
             if max_recursion_depth is not None:
@@ -409,6 +414,10 @@ class SchedulingSolver:
             total_time += sat_computation_time
             if total_time > self.max_time:
                 warnings.warn('max time exceeded')
+                break
+
+            if bound is not None and current_variable_value == bound:
+                print("\tFound optimum %i. Stopping iteration." % current_variable_value)
                 break
 
             # prevent the solver to start a new round if we expect it to be


### PR DESCRIPTION
This PR introduces the following changes already added to max-utilization branch:
 - Adding a **bounds** property to indicators (and objectives) to make the solver stop when it reaches its bound (upper if maximizing or lower if minimizing) since this would be the best possible value.
 - Making **add_objective** methods return indicators so they can be later used in the problem, for instance, in the form of constraints.