### PR TITLE
Changes all version strings for z3-solver from "4.11.2" to "4.11.2.0"…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - pip
   - python=3.8
   - pip:
-    - z3-solver==4.11.2
+    - z3-solver==4.11.2.0
     - matplotlib==3.4.1
     - plotly== 4.14.3
     - kaleido== 0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-z3-solver==4.11.2
+z3-solver==4.11.2.0
 matplotlib==3.4.1
 plotly== 4.14.3
 kaleido== 0.2.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license="GPLv3",
     platforms="Platform Independent",
     packages=find_packages(),
-    install_requires=["z3-solver==4.11.2"],
+    install_requires=["z3-solver==4.11.2.0"],
     classifiers=CLASSIFIERS,
     zip_safe=True,
 )


### PR DESCRIPTION
… as this is the exact version string on pypi. This fixes the problem that ProcessScheduler 0.9.0 currently cannot be installed via [python poetry](https://python-poetry.org/) (and potentially other methods), as it is strict about the exact match if the `==` operator is used.