### PR TITLE
Resolve "Define time spans periodically for ResourceUnavailable"

### DIFF
--- a/processscheduler/__init__.py
+++ b/processscheduler/__init__.py
@@ -63,6 +63,7 @@ from processscheduler.resource_constraint import (
     SameWorkers,
     DistinctWorkers,
     ResourceUnavailable,
+    ResourcePeriodicallyUnavailable,
     WorkLoad,
     ResourceTasksDistance,
     ResourceNonDelay,

--- a/processscheduler/__init__.py
+++ b/processscheduler/__init__.py
@@ -67,6 +67,8 @@ from processscheduler.resource_constraint import (
     WorkLoad,
     ResourceTasksDistance,
     ResourceNonDelay,
+    ResourceInterrupted,
+    ResourcePeriodicallyInterrupted,
 )
 from processscheduler.indicator_constraint import IndicatorTarget, IndicatorBounds
 from processscheduler.resource import Worker, CumulativeWorker, SelectWorkers

--- a/processscheduler/resource_constraint.py
+++ b/processscheduler/resource_constraint.py
@@ -270,7 +270,7 @@ class ResourcePeriodicallyUnavailable(ResourceConstraint):
 
         if not resource_assigned:
             raise AssertionError(
-                "The resource is not assigned to any task. Please first assign the resource to one or more tasks, and then add the ResourceUnavailable constraint."
+                "The resource is not assigned to any task. Please first assign the resource to one or more tasks, and then add the ResourcePeriodicallyUnavailable constraint."
             )
 
 

--- a/processscheduler/resource_constraint.py
+++ b/processscheduler/resource_constraint.py
@@ -378,6 +378,13 @@ class ResourcePeriodicallyInterrupted(ResourceConstraint):
     - list_of_time_intervals: A list of time intervals during which the resource is interrupting any task.
       For example, [(0, 2), (5, 8)] represents time intervals from 0 to 2 and from 5 to 8.
     - optional (bool, optional): Whether the constraint is optional (default is False).
+    - period: The length of one period after which to repeat the list of time intervals.
+      For example, setting this to 5 with [(2, 4)] gives unavailabilities at (2, 4), (7, 9), (12, 14), ...
+    - start: The start after which repeating the list of time intervals is active (default is 0).
+    - offset: The shift of the repeated list of time intervals (default is 0).
+      It might be desired to set also the start parameter to the same value, as otherwise the pattern shifts in from the left or the right into the schedule.
+    - end: The end until which repeating the list of time intervals is activate (default is None).
+    - optional (bool, optional): Whether the constraint is optional (default is False).
     """
 
     resource: Union[Worker, CumulativeWorker]
@@ -394,6 +401,13 @@ class ResourcePeriodicallyInterrupted(ResourceConstraint):
         :param resource: The resource for which interrupts are defined.
         :param list_of_time_intervals: A list of time intervals during which the resource is interrupting any task.
           For example, [(0, 2), (5, 8)] represents time intervals from 0 to 2 and from 5 to 8.
+        :param optional: Whether the constraint is optional (default is False).
+        :param period: The length of one period after which to repeat the list of time intervals.
+          For example, setting this to 5 with [(2, 4)] gives unavailabilities at (2, 4), (7, 9), (12, 14), ...
+        :param start: The start after which repeating the list of time intervals is active (default is 0).
+        :param offset: The shift of the repeated list of time intervals (default is 0).
+          It might be desired to set also the start parameter to the same value, as otherwise the pattern shifts in from the left or the right into the schedule.
+        :param end: The end until which repeating the list of time intervals is activate (default is None).
         :param optional: Whether the constraint is optional (default is False).
         """
         super().__init__(**data)
@@ -491,7 +505,7 @@ class ResourcePeriodicallyInterrupted(ResourceConstraint):
                             task._duration <= task.max_duration + total_overlap
                         )
 
-
+            # TODO: add AND only of mask is set?
             core = z3.And(*conds)
 
             mask = [core]

--- a/processscheduler/resource_constraint.py
+++ b/processscheduler/resource_constraint.py
@@ -197,6 +197,83 @@ class ResourceUnavailable(ResourceConstraint):
             )
 
 
+class ResourcePeriodicallyUnavailable(ResourceConstraint):
+    """
+    This constraint sets the unavailability of a resource in terms of time intervals in one period.
+
+    Parameters:
+    - resource: The resource for which unavailability is defined.
+    - list_of_time_intervals: A list of time intervals *in one period* during which the resource is unavailable for any task.
+      For example, [(0, 2), (5, 8)] represents time intervals from 0 to 2 and from 5 to 8 in one period.
+    - period: The length of one period after which to repeat the list of time intervals.
+      For example, setting this to 5 with [(2, 4)] gives unavailabilities at (2, 4), (7, 9), (12, 14), ...
+    - start: The start after which repeating the list of time intervals is active (default is 0).
+    - offset: The shift of the repeated list of time intervals (default is 0).
+      It might be desired to set also the start parameter to the same value, as otherwise the pattern shifts in from the left or the right into the schedule.
+    - end: The end until which repeating the list of time intervals is activate (default is None).
+    - optional (bool, optional): Whether the constraint is optional (default is False).
+    """
+
+    resource: Union[Worker, CumulativeWorker]
+    list_of_time_intervals: List[Tuple[int, int]]
+    period: int
+    start: int = 0
+    offset: int = 0
+    end: Union[int, None] = None
+
+
+    def __init__(self, **data):
+        """
+        Initialize a ResourceUnavailable constraint.
+
+        :param resource: The resource for which unavailability is defined.
+        :param list_of_time_intervals: A list of time intervals *in one period* during which the resource is unavailable for any task.
+          For example, [(0, 2), (5, 8)] represents time intervals from 0 to 2 and from 5 to 8.
+        :param period: The length of one period after which to repeat the list of time intervals.
+          For example, setting this to 5 with [(2, 4)] gives unavailabilities at (2, 4), (7, 9), (12, 14), ...
+        :param start: The start after which repeating the list of time intervals is active (default is 0).
+        :param offset: The shift of the repeated list of time intervals (default is 0).
+          It might be desired to set also the start parameter to the same value, as otherwise the pattern shifts in from the left or the right into the schedule.
+        :param end: The end until which repeating the list of time intervals is activate (default is None).
+        :param optional: Whether the constraint is optional (default is False).
+        """
+        super().__init__(**data)
+
+        if isinstance(self.resource, Worker):
+            workers = [self.resource]
+        elif isinstance(self.resource, CumulativeWorker):
+            workers = self.resource.cumulative_workers
+
+        resource_assigned = False
+
+        for interval_lower_bound, interval_upper_bound in self.list_of_time_intervals:
+            for worker in workers:
+                for start_task_i, end_task_i in worker.get_busy_intervals():
+                    resource_assigned = True
+                    duration = end_task_i - start_task_i
+                    conds = [
+                        z3.Xor(
+                            (start_task_i - self.offset) % self.period >= interval_upper_bound,
+                            (start_task_i - self.offset) % self.period + duration <= interval_lower_bound
+                        )
+                    ]
+
+                    if self.start > 0:
+                        conds.append(end_task_i <= self.start)
+                    if self.end is not None:
+                        conds.append(start_task_i >= self.end)
+
+                    if len(conds) > 1:
+                        self.set_z3_assertions(z3.Or(*conds))
+                    else:
+                        self.set_z3_assertions(*conds)
+
+        if not resource_assigned:
+            raise AssertionError(
+                "The resource is not assigned to any task. Please first assign the resource to one or more tasks, and then add the ResourceUnavailable constraint."
+            )
+
+
 class ResourceNonDelay(ResourceConstraint):
     """All tasks processed by the resource are contiguous, there's no idle while an operation
     if waiting for processing"""

--- a/test/test_resource_interrupted.py
+++ b/test/test_resource_interrupted.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2020-2021 Thomas Paviot (tpaviot@gmail.com)
+#
+# This file is part of ProcessScheduler.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import processscheduler as ps
+import pytest
+
+
+def test_resource_interrupted_fixed_duration() -> None:
+    pb = ps.SchedulingProblem(name="fixed_duration")
+    task_1 = ps.FixedDurationTask(name="task1", duration=3)
+    task_2 = ps.FixedDurationTask(name="task2", duration=4)
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    task_2.add_required_resource(worker_1)
+    ps.ResourceInterrupted(resource=worker_1, list_of_time_intervals=[(1, 3), (6, 8)])
+
+    ps.ObjectiveMinimizeMakespan()
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 3
+    assert solution.tasks[task_1.name].end == 6
+    assert solution.tasks[task_2.name].start == 8
+    assert solution.tasks[task_2.name].end == 12
+
+def test_resource_interrupted_variable_duration() -> None:
+    pb = ps.SchedulingProblem(name="variable_duration")
+    task_1 = ps.VariableDurationTask(name="task1", min_duration=3)
+    task_2 = ps.FixedDurationTask(name="task2", duration=4)
+    ps.TaskStartAt(task=task_1, value=0) # pin to have a more stable outcome
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    task_2.add_required_resource(worker_1)
+    ps.ResourceInterrupted(resource=worker_1, list_of_time_intervals=[(1, 3), (6, 8)])
+
+    ps.ObjectiveMinimizeMakespan()
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 0
+    assert solution.tasks[task_1.name].end == 8
+    assert solution.tasks[task_2.name].start == 8
+    assert solution.tasks[task_2.name].end == 12
+
+
+def test_resource_interrupted_assignment_assertion() -> None:
+    ps.SchedulingProblem(name="assignment_assertion")
+    worker_1 = ps.Worker(name="Worker1")
+    with pytest.raises(AssertionError):
+        ps.ResourceInterrupted(resource=worker_1, list_of_time_intervals=[(1, 3)])

--- a/test/test_resource_periodically_interrupted.py
+++ b/test/test_resource_periodically_interrupted.py
@@ -60,7 +60,7 @@ def test_resource_periodically_interrupted_variable_duration() -> None:
     solution = solver.solve()
     assert solution
     assert solution.tasks[task_1.name].start == 0
-    assert solution.tasks[task_1.name].end == 4
+    assert solution.tasks[task_1.name].end == 4 or solution.tasks[task_1.name].end == 5
     assert solution.tasks[task_2.name].start == 5
     assert solution.tasks[task_2.name].end == 9
 

--- a/test/test_resource_periodically_interrupted.py
+++ b/test/test_resource_periodically_interrupted.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2020-2021 Thomas Paviot (tpaviot@gmail.com)
+#
+# This file is part of ProcessScheduler.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import processscheduler as ps
+import pytest
+
+
+def test_resource_periodically_interrupted_fixed_duration() -> None:
+    pb = ps.SchedulingProblem(name="fixed_duration")
+    task_1 = ps.FixedDurationTask(name="task1", duration=2)
+    task_2 = ps.FixedDurationTask(name="task2", duration=4)
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    task_2.add_required_resource(worker_1)
+    ps.ResourcePeriodicallyInterrupted(
+        resource=worker_1,
+        list_of_time_intervals=[(1, 2), (4, 5)],
+        period=10
+    )
+
+    ps.ObjectiveMinimizeMakespan()
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 2
+    assert solution.tasks[task_1.name].end == 4
+    assert solution.tasks[task_2.name].start == 5
+    assert solution.tasks[task_2.name].end == 9
+
+
+def test_resource_periodically_interrupted_variable_duration() -> None:
+    pb = ps.SchedulingProblem(name="variable_duration")
+    task_1 = ps.VariableDurationTask(name="task1", min_duration=3)
+    task_2 = ps.FixedDurationTask(name="task2", duration=4)
+    ps.TaskStartAt(task=task_1, value=0) # pin to have a more stable outcome
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    task_2.add_required_resource(worker_1)
+    ps.ResourcePeriodicallyInterrupted(
+        resource=worker_1,
+        list_of_time_intervals=[(1, 2), (4, 5)],
+        period=10
+    )
+
+    ps.ObjectiveMinimizeMakespan()
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 0
+    assert solution.tasks[task_1.name].end == 4
+    assert solution.tasks[task_2.name].start == 5
+    assert solution.tasks[task_2.name].end == 9
+
+
+def test_resource_periodically_interrupted_assignment_assertion() -> None:
+    ps.SchedulingProblem(name="assignment_assertion")
+    worker_1 = ps.Worker(name="Worker1")
+    with pytest.raises(AssertionError):
+        ps.ResourcePeriodicallyInterrupted(resource=worker_1, list_of_time_intervals=[(1, 3)], period=6)
+
+
+def test_resource_periodically_interrupted_period_assertion() -> None:
+    ps.SchedulingProblem(name="period_assertion")
+    worker_1 = ps.Worker(name="Worker1")
+    with pytest.raises(AssertionError):
+        ps.ResourcePeriodicallyInterrupted(resource=worker_1, list_of_time_intervals=[(1, 2), (3, 5)], period=4)

--- a/test/test_resource_periodically_unavailable.py
+++ b/test/test_resource_periodically_unavailable.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2020-2021 Thomas Paviot (tpaviot@gmail.com)
+#
+# This file is part of ProcessScheduler.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import processscheduler as ps
+
+import pytest
+
+
+def test_resource_periodically_unavailable_1() -> None:
+    pb = ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable1", horizon=10)
+    task_1 = ps.FixedDurationTask(name="task1", duration=3)
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    ps.ResourcePeriodicallyUnavailable(resource=worker_1, list_of_time_intervals=[(1, 3), (6, 8)], period=10)
+
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 3
+    assert solution.tasks[task_1.name].end == 6
+
+
+def test_resource_periodically_unavailable_2() -> None:
+    pb = ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable2", horizon=10)
+    task_1 = ps.FixedDurationTask(name="task1", duration=3)
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    # difference with the first one: build 2 constraints
+    # merged using a and_
+    ps.ResourcePeriodicallyUnavailable(resource=worker_1, list_of_time_intervals=[(1, 3)], period=10)
+    ps.ResourcePeriodicallyUnavailable(resource=worker_1, list_of_time_intervals=[(6, 8)], period=10)
+
+    # that should not change the problem solution
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 3
+    assert solution.tasks[task_1.name].end == 6
+
+
+def test_resource_periodically_unavailable_3() -> None:
+    pb = ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable3", horizon=10)
+    task_1 = ps.FixedDurationTask(name="task1", duration=3)
+    worker_1 = ps.Worker(name="Worker1")
+    task_1.add_required_resource(worker_1)
+    # difference with the previous ones: too much unavailability,
+    # so possible solution
+    # merged using a and_
+    ps.ResourcePeriodicallyUnavailable(resource=worker_1, list_of_time_intervals=[(1, 3)], period=10)
+    ps.ResourcePeriodicallyUnavailable(resource=worker_1, list_of_time_intervals=[(5, 8)], period=10)
+
+    # that should not change the problem solution
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert not solution
+
+
+def test_resource_periodically_unavailable_4() -> None:
+    ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable4", horizon=10)
+    worker_1 = ps.Worker(name="Worker1")
+    with pytest.raises(AssertionError):
+        ps.ResourcePeriodicallyUnavailable(resource=worker_1, list_of_time_intervals=[(1, 3)], period=10)
+
+
+def test_resource_periodically_unavailable_5() -> None:
+    pb = ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable5", horizon=15)
+    task_1 = ps.FixedDurationTask(name="task1", duration=3)
+    task_2 = ps.FixedDurationTask(name="task2", duration=3)
+    task_3 = ps.FixedDurationTask(name="task3", duration=3)
+    ps.TaskPrecedence(task_before=task_1, task_after=task_2)
+    ps.TaskPrecedence(task_before=task_2, task_after=task_3)
+    worker_1 = ps.Worker(name="Worker1")
+    for task in (task_1, task_2, task_3):
+        task.add_required_resource(worker_1)
+    ps.ResourcePeriodicallyUnavailable(
+        resource=worker_1,
+        list_of_time_intervals=[(3, 5)],
+        period=5
+    )
+
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 0
+    assert solution.tasks[task_1.name].end == 3
+    assert solution.tasks[task_2.name].start == 5
+    assert solution.tasks[task_2.name].end == 8
+    assert solution.tasks[task_3.name].start == 10
+    assert solution.tasks[task_3.name].end == 13
+
+
+def test_resource_periodically_unavailable_6() -> None:
+    pb = ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable6", horizon=17)
+    task_1 = ps.FixedDurationTask(name="task1", duration=3)
+    task_2 = ps.FixedDurationTask(name="task2", duration=3)
+    task_3 = ps.FixedDurationTask(name="task3", duration=3)
+    task_4 = ps.FixedDurationTask(name="task4", duration=3)
+    ps.TaskPrecedence(task_before=task_1, task_after=task_2)
+    ps.TaskPrecedence(task_before=task_2, task_after=task_3)
+    ps.TaskPrecedence(task_before=task_3, task_after=task_4)
+    worker_1 = ps.Worker(name="Worker1")
+    for task in (task_1, task_2, task_3, task_4):
+        task.add_required_resource(worker_1)
+    ps.ResourcePeriodicallyUnavailable(
+        resource=worker_1,
+        list_of_time_intervals=[(2, 4)],
+        offset=2, # shift interval to (4, 6)
+        start=3,  # TODO: end_task_i <= start, so it must be set to the task duration
+        end=14,   # unavailability interval at (14, 16), but it should be ignored
+        period=5
+    )
+    ps.ResourceUnavailable(
+        resource=worker_1,
+        list_of_time_intervals=[(3, 4)] # leaving task_1 starting at 0 as only option
+    )
+
+    ps.ObjectiveMinimizeMakespan() # ensure dense packing
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 0  # unavailability at (0, 1) ignored
+    assert solution.tasks[task_1.name].end == 3
+    assert solution.tasks[task_2.name].start == 6
+    assert solution.tasks[task_2.name].end == 9    # expected unavailability
+    assert solution.tasks[task_3.name].start == 11
+    assert solution.tasks[task_3.name].end == 14
+    assert solution.tasks[task_4.name].start == 14 # unavailability at (14, 16) ignored
+    assert solution.tasks[task_4.name].end == 17

--- a/test/test_resource_periodically_unavailable.py
+++ b/test/test_resource_periodically_unavailable.py
@@ -118,7 +118,7 @@ def test_resource_periodically_unavailable_6() -> None:
         resource=worker_1,
         list_of_time_intervals=[(2, 4)],
         offset=2, # shift interval to (4, 6)
-        start=3,  # TODO: end_task_i <= start, so it must be set to the task duration
+        start=3,  # end_task_i <= start, so it must be set to the task duration
         end=14,   # unavailability interval at (14, 16), but it should be ignored
         period=5
     )

--- a/test/test_resource_periodically_unavailable.py
+++ b/test/test_resource_periodically_unavailable.py
@@ -139,3 +139,30 @@ def test_resource_periodically_unavailable_6() -> None:
     assert solution.tasks[task_3.name].end == 14
     assert solution.tasks[task_4.name].start == 14 # unavailability at (14, 16) ignored
     assert solution.tasks[task_4.name].end == 17
+
+def test_resource_periodically_unavailable_7() -> None:
+    pb = ps.SchedulingProblem(name="ResourcePeriodicallyUnavailable3")
+    task_1 = ps.FixedDurationTask(name="task1", duration=2)
+    task_2 = ps.FixedDurationTask(name="task2", duration=1)
+    task_3 = ps.FixedDurationTask(name="task3", duration=1)
+    ps.TaskPrecedence(task_before=task_1, task_after=task_2)
+    ps.TaskPrecedence(task_before=task_2, task_after=task_3)
+    worker_1 = ps.Worker(name="Worker1")
+    for task in (task_1, task_2, task_3):
+        task.add_required_resource(worker_1)
+    ps.ResourcePeriodicallyUnavailable(
+        resource=worker_1,
+        list_of_time_intervals=[(1, 2), (3, 4)],
+        period=5
+    )
+
+    ps.ObjectiveMinimizeMakespan()
+    solver = ps.SchedulingSolver(problem=pb)
+    solution = solver.solve()
+    assert solution
+    assert solution.tasks[task_1.name].start == 4
+    assert solution.tasks[task_1.name].end == 6
+    assert solution.tasks[task_2.name].start == 7
+    assert solution.tasks[task_2.name].end == 8
+    assert solution.tasks[task_3.name].start == 9
+    assert solution.tasks[task_3.name].end == 10


### PR DESCRIPTION
This PR presents an additional `ResourceConstraint` basing class `ResourcePeriodicallyUnavailable`, which enables the user to give a list of time intervals in which a resource is unavailable and to repeat that pattern indefinitely. The periodicity, the offset as well as the range in which the pattern is repeated can be controlled by setting the respective parameters.
Using modulo calculation, this adds only one solver assertion for one interval, regardless of the number of repetitions.

Fixes #141