### PR TITLE
Sort Gantt Chart tasks chronologically

### DIFF
--- a/processscheduler/plotter.py
+++ b/processscheduler/plotter.py
@@ -18,6 +18,8 @@ import random
 from typing import Optional, Tuple, Union
 import warnings
 
+from processscheduler.task_constraint import TaskStartAt
+
 try:
     import numpy as np
 
@@ -45,7 +47,7 @@ from processscheduler.function import (
     LinearFunction,
     PolynomialFunction,
 )
-from processscheduler.solution import SchedulingSolution
+from processscheduler.solution import SchedulingSolution, TaskSolution
 
 
 def plot_function(
@@ -92,7 +94,14 @@ def plot_function(
     if show_plot:
         plt.show()
 
-
+def sort_by_task_start(tasks: dict[str, TaskSolution], solution: SchedulingSolution) -> dict[str, TaskSolution]:
+    return dict(
+        sorted(
+            tasks.items(),
+            key=lambda item: solution.tasks[item[0]].start,
+            reverse=True
+        )
+    )
 #
 # Gantt graphical rendering using plotly and matplotlib
 #
@@ -123,13 +132,7 @@ def render_gantt_plotly(
     if render_mode == "Task":
         tasks_to_render = solution.get_scheduled_tasks()
         if sort_by_start:
-            tasks_to_render = dict(
-                sorted(
-                    tasks_to_render.items(),
-                    key=lambda item: solution.tasks[item[0]].start,
-                    reverse=True
-                )
-            )
+            tasks_to_render = sort_by_task_start(tasks_to_render, solution)
     else:
         tasks_to_render = solution.tasks
 
@@ -239,13 +242,7 @@ def render_gantt_matplotlib(
             solution.get_scheduled_tasks()
         )  # get_all_tasks_but_unavailable()
         if sort_by_start:
-            tasks_to_render = dict(
-                sorted(
-                    tasks_to_render.items(),
-                    key=lambda item: solution.tasks[item[0]].start,
-                    reverse=True
-                )
-            )
+            tasks_to_render = sort_by_task_start(tasks_to_render, solution)
     else:
         tasks_to_render = solution.tasks
 

--- a/processscheduler/plotter.py
+++ b/processscheduler/plotter.py
@@ -105,6 +105,7 @@ def render_gantt_plotly(
     sort: Optional[str] = None,
     fig_filename: Optional[str] = None,
     html_filename: Optional[str] = None,
+    sort_by_start: bool = False,
 ) -> None:
     """Use plotly.create_gantt method, see
     https://plotly.github.io/plotly.py-docs/generated/plotly.figure_factory.create_gantt.html
@@ -121,6 +122,14 @@ def render_gantt_plotly(
     # tasks to render
     if render_mode == "Task":
         tasks_to_render = solution.get_scheduled_tasks()
+        if sort_by_start:
+            tasks_to_render = dict(
+                sorted(
+                    tasks_to_render.items(),
+                    key=lambda item: solution.tasks[item[0]].start,
+                    reverse=True
+                )
+            )
     else:
         tasks_to_render = solution.tasks
 
@@ -209,6 +218,7 @@ def render_gantt_matplotlib(
     show_indicators: Optional[bool] = True,
     render_mode: Optional[str] = "Resource",
     fig_filename: Optional[str] = None,
+    sort_by_start: bool = False
 ) -> None:
     """generate a gantt diagram using matplotlib.
     Inspired by
@@ -228,6 +238,14 @@ def render_gantt_matplotlib(
         tasks_to_render = (
             solution.get_scheduled_tasks()
         )  # get_all_tasks_but_unavailable()
+        if sort_by_start:
+            tasks_to_render = dict(
+                sorted(
+                    tasks_to_render.items(),
+                    key=lambda item: solution.tasks[item[0]].start,
+                    reverse=True
+                )
+            )
     else:
         tasks_to_render = solution.tasks
 


### PR DESCRIPTION
Currently, tasks were displayed in the order output by the dictionary containing the tasks. This corresponded to the order in which they were entered into the dictionary, I believe. When working with growing projects, the tasks entered would not necessarily be entered into the dictionary in the order the solver recommended executing them. A typical gantt chart sorts tasks in descending chronological order so that tasks needing to be done first appear at the top of the list.

This PR includes one small new function to sort tasks by the solution start date, and an optional parameter passed to the plotting functions for choosing the traditional or sorted output. By default, sorting is not done, causing no change to users existing scripts. 

I believe this PR slightly expands the out-of-the-box usefulness of this library, with minimal additional complexity. Any critique or modifications are welcome.

## Summary by Sourcery

Add functionality to sort Gantt chart tasks chronologically by their start date, with an optional parameter to enable this sorting in the plotting functions.

New Features:
- Introduce a new function to sort Gantt chart tasks by their solution start date.

Enhancements:
- Add an optional parameter to the plotting functions to allow users to choose between traditional or sorted task output.